### PR TITLE
fix: move the warn function to warning on the core

### DIFF
--- a/src/index.test.js
+++ b/src/index.test.js
@@ -26,7 +26,6 @@ jest.mock("./apiCalls", () => ({
 jest.mock("@actions/core", () => {
   const coreMock = {
     info: jest.fn(),
-    warn: jest.fn(),
     getInput: jest.fn(),
   };
   return coreMock;

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -266,4 +266,155 @@ describe("test and publish transformation and libraries successfully", () => {
       readFile("./src/testdata/expected.json"),
     ); // actual file generated is as expected
   });
+
+  it("should throw an error in case testing the transformations / libraries fails", async() => {
+    const metapath = "./src/testdata/meta.json";
+
+    getAllTransformations.mockResolvedValue({
+      data: {
+        transformations: [
+          { name: "Transformation_1", id: "transformation_id_1" },
+        ],
+      },
+    });
+
+    getAllLibraries.mockResolvedValue({
+      data: {
+        libraries: [
+          { name: "getFinanceData", id: "library_id_1" },
+          { name: "getUserAddress", id: "library_id_2" },
+        ],
+      },
+    });
+
+    updateTransformation.mockResolvedValue({
+      data: {
+        id: "transformation_id_1",
+        versionId: "transformation_version_id_1",
+      },
+    });
+
+    updateLibrary
+    .mockReturnValueOnce({
+      data: {
+        id: "library_id_1",
+        versionId: "library_version_id_1",
+      },
+    })
+    .mockReturnValueOnce({
+      data: {
+        id: "library_id_2",
+        versionId: "library_version_id_2",
+      },
+    });
+
+    testTransformationAndLibrary.mockResolvedValue({
+      data: {
+        result: {
+          successTestResults: [
+          ],
+          failedTestResults: [
+            {
+              id : "transformation-id",
+              name: "some-upstream-transformation",
+              error: '{"success": false, "error": "some error message"}',
+            }
+          ],
+        },
+      },
+    });
+
+    await expect(testAndPublish(metapath)).rejects.toThrow(
+      "Failures occured while running tests against input events",
+    );
+  });
+
+  it ("should handle case when library is connected to transformations not managed within the workflow", async() => {
+    const metapath = "./src/testdata/meta.json";
+
+    getAllTransformations.mockResolvedValue({
+      data: {
+        transformations: [
+          { name: "Transformation_1", id: "transformation_id_1" },
+        ],
+      },
+    });
+
+    getAllLibraries.mockResolvedValue({
+      data: {
+        libraries: [
+          { name: "getFinanceData", id: "library_id_1" },
+          { name: "getUserAddress", id: "library_id_2" },
+        ],
+      },
+    });
+
+    updateTransformation.mockResolvedValue({
+      data: {
+        id: "transformation_id_1",
+        versionId: "transformation_version_id_1",
+      },
+    });
+
+    updateLibrary
+      .mockReturnValueOnce({
+        data: {
+          id: "library_id_1",
+          versionId: "library_version_id_1",
+        },
+      })
+      .mockReturnValueOnce({
+        data: {
+          id: "library_id_2",
+          versionId: "library_version_id_2",
+        },
+      });
+
+      testTransformationAndLibrary.mockResolvedValue({
+        data: {
+          result: {
+            successTestResults: [
+              {
+                transformerVersionID: "transformation_version_id_1",
+                result: {
+                  output: {
+                    transformedEvents: [
+                      {
+                        revenue: 0,
+                        price: 0,
+                        profit: 0,
+                        city: "Kolkata",
+                        country: "India",
+                        street: "330/8",
+                      },
+                      {
+                        revenue: 15,
+                        price: 20,
+                        profit: 5,
+                        city: "no data found",
+                        country: "no data found",
+                        street: "no data found",
+                      },
+                    ],
+                  },
+                },
+              },
+              {
+                transformerVersionID: "other_connection_transformation_version_id",
+                result: {
+                  output: {
+                    transformedEvents: [{}],
+                  },
+                },
+              },
+            ],
+            failedTestResults: [],
+          },
+        },
+      });
+
+      await expect(testAndPublish(metapath)).resolves.toEqual(undefined);
+    
+  });
+
 });

--- a/src/main.js
+++ b/src/main.js
@@ -86,7 +86,6 @@ async function upsertTransformations(transformations, transformationNameToId) {
         tr.language,
       );
     } else {
-      core.info(`Creating transformation: ${tr.name}`);
       // create new transformer
       res = await createTransformation(
         tr.name,
@@ -193,6 +192,7 @@ async function compareOutput(successResults, transformationDict) {
     if (!fs.existsSync(testOutputDir)) {
       fs.mkdirSync(testOutputDir);
     }
+
     if (!transformationDict.hasOwnProperty(transformerVersionID)) {
       continue;
     }

--- a/src/main.js
+++ b/src/main.js
@@ -194,9 +194,6 @@ async function compareOutput(successResults, transformationDict) {
       fs.mkdirSync(testOutputDir);
     }
     if (!transformationDict.hasOwnProperty(transformerVersionID)) {
-      core.warning(
-        `Transformer with version id: ${transformerVersionID} not found.`,
-      );
       continue;
     }
 

--- a/src/main.js
+++ b/src/main.js
@@ -194,7 +194,7 @@ async function compareOutput(successResults, transformationDict) {
       fs.mkdirSync(testOutputDir);
     }
     if (!transformationDict.hasOwnProperty(transformerVersionID)) {
-      core.warn(
+      core.warning(
         `Transformer with version id: ${transformerVersionID} not found.`,
       );
       continue;


### PR DESCRIPTION
## Description of the change

With recent refactoring efforts on the transformations action code to improve the code coverage etc, we added a warning log using actions/core with convention as `core.warn()`. This was added in the release `v1.1.2`. Changes in the PR:

1. This was a breaking change as the fn doesn't exist. The test covering the codepath also wasn't added which resulted in the change going in undetected. This change fixes it by removing the warn log altogether.

2. We also have added tests now for covering some of the missing paths in the action code.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
